### PR TITLE
Added concourse service

### DIFF
--- a/concourse/docker-compose.yml
+++ b/concourse/docker-compose.yml
@@ -1,0 +1,28 @@
+---
+version: "3"
+
+services:
+  concourse-db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=concourse
+      - POSTGRES_PASSWORD=concourse_pass
+      - POSTGRES_USER=concourse_user
+      - PGDATA=/database
+
+  concourse:
+    image: concourse/concourse
+    command: quickstart
+    privileged: true
+    depends_on: [concourse-db]
+    ports: ["8080:8080"]
+    environment:
+      - CONCOURSE_POSTGRES_HOST=concourse-db
+      - CONCOURSE_POSTGRES_USER=concourse_user
+      - CONCOURSE_POSTGRES_PASSWORD=concourse_pass
+      - CONCOURSE_POSTGRES_DATABASE=concourse
+      - CONCOURSE_EXTERNAL_URL=http://192.168.50.50:8080
+      - CONCOURSE_ADD_LOCAL_USER=admin:admin
+      - CONCOURSE_MAIN_TEAM_LOCAL_USER=admin
+    volumes:
+      - ./resolv.conf:/etc/resolv.conf

--- a/concourse/resolv.conf
+++ b/concourse/resolv.conf
@@ -1,0 +1,3 @@
+nameserver 127.0.0.11
+options edns0 trust-ad ndots:0
+nameserver 8.8.8.8


### PR DESCRIPTION
Note that the IP is hard coded as an internal IP address and the username/password is set as the default from the tutorial. 
DON'T USE THIS ON AN EXTERNAL SERVER!
Other thing to note: was having trouble with the DNS and so created a custom resolv.conf which solved the issue, although it is a hack.